### PR TITLE
Update sort.htm

### DIFF
--- a/en/hhstndrd/sort.htm
+++ b/en/hhstndrd/sort.htm
@@ -16,9 +16,12 @@ The file for input is not modified.
   <b>/+n</b>
   Begin sorting at column n in each line of text.  Default=1.
 
+  <b>/A</b>
+  Sort by ASCII value, disables sorting by National Language.
+
   <b>/N</b>
-  Enables National Language Support, so that messages will be
-  displayed according to the setting of the LANG environment variable.
+  Enables National Language Support (enabled by default in sort version 1.3+), 
+  so that messages will be displayed according to the setting of the LANG environment variable.
   Use the <a href="set.htm">set</a> command to set LANG.
 </pre>
 <h2>Examples</h2>


### PR DESCRIPTION
Document /A ASCII sort option added in 2004.  Add a note about /N NLS Support being enabled by default since sort version 1.3.